### PR TITLE
chore(demo-jwt-auth): update deps @waiting/egg-jwt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
 install:

--- a/demo-jwt-auth/package.json
+++ b/demo-jwt-auth/package.json
@@ -4,7 +4,7 @@
   "description": "midway boilerplate",
   "private": true,
   "dependencies": {
-    "@waiting/egg-jwt": "^2.0.0",
+    "@waiting/egg-jwt": "^3.0.0",
     "egg-scripts": "^2.11.0",
     "midway": "1"
   },

--- a/demo-jwt-auth/test/app/home/home.test.ts
+++ b/demo-jwt-auth/test/app/home/home.test.ts
@@ -23,86 +23,113 @@ describe(filename, () => {
     // await ctx.service.xx();
   })
 
-  it('should GET /', async () => {
-    const ret = await app.httpRequest()
-      .get('/')
-      .expect(200)
 
-    const msg: string = ret.res.text
-    assert(msg && msg.includes('Hello midwayjs!'))
-  })
+  // src/config/config.default.ts
+  describe('Not in ignore config:', () => {
+    it('should error w/o token', async () => {
+      const ret = await app.httpRequest()
+        .get('/token')
+        .expect(401)
 
-  it('should GET /hello', async () => {
-    const ret = await app.httpRequest()
-      .get('/hello')
-      .expect(200)
-
-    const msg: string = ret.res.text
-    assert(msg && msg.includes('Hello midwayjs!'))
-  })
-
-  it('should GET /test_sign', async () => {
-    const ret = await app.httpRequest()
-      .get('/test_sign')
-      .expect(200)
-
-    const msg: string = ret.res.text
-    assert(msg && msg.includes('{"foo":"bar",'))
-    assert(msg.includes(header1))
-  })
-
-
-  it('should error w/o token', async () => {
-    const ret = await app.httpRequest()
-      .get('/token')
-      .expect(401)
-
-    const msg: string = ret.res.text
-    assert(msg && msg.includes(JwtMsg.AuthFailed))
-  })
-
-  it('should works with invalid header auth', async () => {
-    const ret = await app.httpRequest()
-      .get('/token')
-      .set('authorization', `${schemePrefix} ${token1}    `)
-      .expect(401)
-
-    const msg: string = ret.res.text
-    assert(msg && msg.includes(JwtMsg.AuthFailed))
-  })
-
-  it('should works with header auth', async () => {
-    const ret = await app.httpRequest()
-      .get('/token')
-      .set('authorization', `${schemePrefix} ${token1}`)
-      .expect(200)
-
-    const msg: string = ret.res.text
-    assert(msg && msg.includes(expectPayloadStr))
-  })
-
-  it('should works with cookies auth', async () => {
-    app.mockCookies({
-      access_token: token1,
+      const msg: string = ret.text
+      assert(msg && msg.includes(JwtMsg.AuthFailed))
     })
-    const ret = await app.httpRequest()
-      .get('/token')
-      .expect(200)
 
-    const msg: string = ret.res.text
-    assert(msg && msg.includes(expectPayloadStr))
+    it('should works with invalid header format', async () => {
+      const ret = await app.httpRequest()
+        .get('/token')
+        .set('authorization', `${schemePrefix} ${token1}FAKE`)
+        .expect(401)
+
+      const msg: string = ret.text
+      assert(msg && msg.includes(JwtMsg.AuthFailed))
+    })
+
+    it('should works with header format', async () => {
+      const ret = await app.httpRequest()
+        .get('/token')
+        .set('authorization', `${schemePrefix} FAKE`)
+        .expect(401)
+
+      console.log('ret>>>>', ret)
+      const msg: string = ret.text
+      assert(msg && msg.includes(JwtMsg.AuthFailed))
+    })
+
+    it('should works with invalid header auth', async () => {
+      const ret = await app.httpRequest()
+        .get('/token')
+        .set('authorization', `${schemePrefix} ${token1.toLowerCase()}`)
+        .expect(401)
+
+      const msg: string = ret.text
+      assert(msg && msg.includes(JwtMsg.AuthFailed))
+    })
+
+    it('should works with header auth', async () => {
+      const ret = await app.httpRequest()
+        .get('/token')
+        .set('authorization', `${schemePrefix} ${token1}`)
+        .expect(200)
+
+      const msg: string = ret.text
+      assert(msg && msg.includes(expectPayloadStr))
+    })
+
+    it('should works with cookies auth', async () => {
+      app.mockCookies({
+        access_token: token1,
+      })
+      const ret = await app.httpRequest()
+        .get('/token')
+        .expect(200)
+
+      const msg: string = ret.text
+      assert(msg && msg.includes(expectPayloadStr))
+    })
+
+    it('should redirect w/o token', async () => {
+      // config at src/config/config.local.ts
+      const url = '/test_passthrough_redirect'
+      const ret = await app.httpRequest()
+        .get(url)
+        .expect(302)
+
+      const msg: string = ret.text
+      assert(msg && msg.includes('Redirecting'))
+      assert(msg.includes(`${url}_path`))
+    })
   })
 
+  // src/config/config.default.ts
+  describe('In ignore config:', () => {
+    it('should GET /', async () => {
+      const ret = await app.httpRequest()
+        .get('/')
+        .expect(200)
 
-  it('should redirect w/o token', async () => {
-    // config at src/config/config.local.ts
-    const url = '/test_passthrough_redirect'
-    const ret = await app.httpRequest()
-      .get(url)
-      .expect(302)
+      const msg: string = ret.text
+      assert(msg && msg.includes('Hello midwayjs!'))
+    })
 
-    const msg: string = ret.res.text
-    assert(msg && msg.includes('Redirecting'))
-    assert(msg.includes(`${url}_path`))
+    it('should GET /hello', async () => {
+      const ret = await app.httpRequest()
+        .get('/hello')
+        .expect(200)
+
+      const msg: string = ret.text
+      assert(msg && msg.includes('Hello midwayjs!'))
+    })
+
+    it('should GET /test_sign', async () => {
+      const ret = await app.httpRequest()
+        .get('/test_sign')
+        .expect(200)
+
+      const msg: string = ret.text
+      assert(msg && msg.includes('{"foo":"bar",'))
+      assert(msg.includes(header1))
+    })
   })
+
 })

--- a/demo-jwt-auth/test/app/home/home.test.ts
+++ b/demo-jwt-auth/test/app/home/home.test.ts
@@ -51,7 +51,6 @@ describe(filename, () => {
         .set('authorization', `${schemePrefix} FAKE`)
         .expect(401)
 
-      console.log('ret>>>>', ret)
       const msg: string = ret.text
       assert(msg && msg.includes(JwtMsg.AuthFailed))
     })

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,7 @@
       ]
     },
     "run": {
-      "ignore": ["demo-sequelize", "demo-sequelize-typescript", "demo-nacos", "demo-plugin-egg-mysql"]
+      "ignore": ["demo-sequelize", "demo-sequelize-typescript", "demo-nacos", "demo-plugin-egg-mysql", "demo-plugin-egg-socket-io"]
     }
   },
   "version": "1.0.0"

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,14 @@
       ]
     },
     "run": {
-      "ignore": ["demo-sequelize", "demo-sequelize-typescript", "demo-nacos", "demo-plugin-egg-mysql", "demo-plugin-egg-socket-io"]
+      "ignore": [
+        "demo-sequelize", 
+        "demo-sequelize-typescript", 
+        "demo-nacos", 
+        "demo-plugin-egg-mysql", 
+        "demo-plugin-egg-socket-io",
+        "demo-demo-view-ejs-locals"
+      ]
     }
   },
   "version": "1.0.0"

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,7 @@
       ]
     },
     "run": {
-      "ignore": ["demo-sequelize", "demo-sequelize-typescript", "demo-nacos"]
+      "ignore": ["demo-sequelize", "demo-sequelize-typescript", "demo-nacos", "demo-plugin-egg-mysql"]
     }
   },
   "version": "1.0.0"


### PR DESCRIPTION
from v2 to v3
主要变动：

SHA-1: 0f9b97fac586b90e2ec0ec58b8697e0e8b987a9f
* feat: trim trailing white space from cookies/header
according to Node.js security since v10.19, v12.15
@link https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/
